### PR TITLE
Implement public transit next departures widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ owm_lon = 12.37
 url = "https://hnrss.org/newest"
 
 [widgets.transit]
-# Your here.org API key
+# Your developer.here.com API key
 here_api_key = ""
 # The latitude and longitude of the location where blimp will look for the next public transit departures
 here_lat = 51.33

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _I built this to run on a RaspberryPi Zero inside a Macintosh 1 on my shelf to q
 - **Network Latency**: Display a live chart of the network latency / ping
 - **Application Status**: Monitor the status of web applications
 - **RSS, Atom & JSON Feeds**: Display the most recent items from multiple feeds
+- **Public transit next departures**: Dispaly the next departures from public transit stations nearby
 
 ## Installation
 
@@ -58,6 +59,15 @@ owm_lon = 12.37
 
 [[widgets.feeds.targets]]
 url = "https://hnrss.org/newest"
+
+[widgets.transit]
+# Your here.org API key
+here_api_key = ""
+# The latitude and longitude of the location where blimp will look for the next public transit departures
+here_lat = 51.33
+here_lon = 12.37
+# The search radius around the coordinates in meters
+here_radius = 500
 ```
 
 ## Configure the layout

--- a/internal/app.go
+++ b/internal/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/merlinfuchs/blimp/internal/widgets/feeds"
 	"github.com/merlinfuchs/blimp/internal/widgets/latency"
 	"github.com/merlinfuchs/blimp/internal/widgets/status"
+	"github.com/merlinfuchs/blimp/internal/widgets/transit"
 	"github.com/merlinfuchs/blimp/internal/widgets/weather"
 	"github.com/rivo/tview"
 )
@@ -21,6 +22,7 @@ func AppEntry() error {
 		"status":  status.New(),
 		"weather": weather.New(),
 		"feeds":   feeds.New(),
+		"transit": transit.New(),
 	}
 
 	pages, err := parsePagesFromConfig()

--- a/internal/config/default.config.toml
+++ b/internal/config/default.config.toml
@@ -33,3 +33,6 @@ update_interval = 60000 # 1 minutes
 max_items = 0 # 0 means auto
 show_feed_title = true
 show_published_time = true
+
+[widgets.transit]
+here_radius = 500

--- a/internal/widgets/transit/api.go
+++ b/internal/widgets/transit/api.go
@@ -1,0 +1,69 @@
+package transit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/merlinfuchs/blimp/internal/config"
+)
+
+type DeparturesData struct {
+	Boards []DeparturesBoardData `json:"boards"`
+}
+
+type DeparturesBoardData struct {
+	Place struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Location struct {
+			Lat float64 `json:"lat"`
+			Lon float64 `json:"lng"`
+		} `json:"location"`
+	} `json:"place"`
+	Departures []struct {
+		Time      time.Time `json:"time"`
+		Platform  string    `json:"platform"`
+		Transport struct {
+			Mode      string `json:"mode"`
+			Name      string `json:"name"`
+			Category  string `json:"category"`
+			Color     string `json:"color"`
+			TextColor string `json:"textColor"`
+			HeadSign  string `json:"headsign"`
+			ShortName string `json:"shortName"`
+		} `json:"transport"`
+		Agency struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"agency"`
+	} `json:"departures"`
+}
+
+func getNextDeparturesData() (DeparturesData, error) {
+	url := fmt.Sprintf(
+		"https://transit.hereapi.com/v8/departures?in=%f,%f;r=%d&apiKey=%s",
+		config.K.Float64("widgets.transit.here_lat"),
+		config.K.Float64("widgets.transit.here_lon"),
+		config.K.Int("widgets.transit.here_radius"),
+		config.K.String("widgets.transit.here_api_key"),
+	)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return DeparturesData{}, fmt.Errorf("failed to get next departures data: %w", err)
+	}
+
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+		return DeparturesData{}, fmt.Errorf("Failed to get next departures aata, status code %d", resp.StatusCode)
+	}
+
+	var data DeparturesData
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return DeparturesData{}, fmt.Errorf("Failed to decode next departures data, %w", err)
+	}
+
+	return data, nil
+}

--- a/internal/widgets/transit/transit.go
+++ b/internal/widgets/transit/transit.go
@@ -1,0 +1,145 @@
+package transit
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/merlinfuchs/blimp/internal/config"
+	"github.com/rivo/tview"
+)
+
+type TransitView struct {
+	view   *tview.Flex
+	ticker *time.Ticker
+	items  []DepartureItem
+}
+
+func New() *TransitView {
+	view := tview.NewFlex().SetDirection(tview.FlexRow)
+	view.SetBorder(true).
+		SetBorderColor(tcell.ColorGray).
+		SetTitle("Next Departures").
+		SetTitleAlign(tview.AlignLeft).
+		SetBorderPadding(1, 1, 1, 1)
+
+	return &TransitView{
+		view: view,
+	}
+}
+
+func (l *TransitView) Start() {
+	l.ticker = time.NewTicker(1 * time.Minute)
+	err := l.updateItems()
+	if err != nil {
+		slog.With("error", err).Error("Failed to update items")
+		panic(err)
+	}
+}
+
+func (l *TransitView) Stop() {
+	if l.ticker != nil {
+		l.ticker.Stop()
+	}
+}
+
+func (l *TransitView) Update() error {
+	if l.ticker == nil {
+		return nil
+	}
+
+	select {
+	case <-l.ticker.C:
+		err := l.updateItems()
+		if err != nil {
+			return fmt.Errorf("failed to update items: %w", err)
+		}
+	default:
+	}
+
+	l.updateView()
+	return nil
+}
+
+type DepartureItem struct {
+	PlaceName string
+	Name      string
+	HeadSign  string
+	ShortName string
+	Platform  string
+	Category  string
+	Departure time.Time
+}
+
+func (l *TransitView) updateItems() error {
+	nextDepartures, err := getNextDeparturesData()
+	if err != nil {
+		return fmt.Errorf("failed to get next departures data: %w", err)
+	}
+
+	items := make([]DepartureItem, 0)
+	for _, board := range nextDepartures.Boards {
+		for _, departure := range board.Departures {
+			items = append(items, DepartureItem{
+				PlaceName: board.Place.Name,
+				Name:      departure.Transport.Name,
+				HeadSign:  departure.Transport.HeadSign,
+				ShortName: departure.Transport.ShortName,
+				Platform:  departure.Platform,
+				Category:  departure.Transport.Category,
+				Departure: departure.Time,
+			})
+		}
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Departure.Before(items[j].Departure)
+	})
+	l.items = items
+
+	return nil
+}
+
+func (l *TransitView) updateView() error {
+	l.view.Clear()
+
+	maxItems := config.K.Int("widgets.transit.max_items")
+	if maxItems == 0 {
+		_, _, _, height := l.view.GetRect()
+		maxItems = height - 4
+	}
+
+	items := l.items
+	if len(items) > maxItems {
+		items = items[:maxItems]
+	}
+
+	for _, item := range items {
+		departureMinutes := item.Departure.Sub(time.Now()).Minutes()
+		if departureMinutes < 0 {
+			departureMinutes = 0
+		}
+
+		l.view.AddItem(
+			tview.NewTextView().
+				SetText(fmt.Sprintf(
+					"[gray]- [yellowgreen]%d min (%s) [white]%s [lightgray]%s [gray]%s",
+					int(departureMinutes),
+					item.Departure.Format("15:04"),
+					item.Name,
+					item.HeadSign,
+					item.PlaceName,
+				)).
+				SetDynamicColors(true).
+				SetWrap(false),
+			1, 1, false)
+	}
+
+	return nil
+}
+
+func (l *TransitView) Primitive() tview.Primitive {
+	return l.view
+}


### PR DESCRIPTION
This widget displays the next departures of public transport stations nearby. Users can configure the serach location and radius. The widget automatically detects how many items it can display in the view.

Powered by the developer.here.com API.

![grafik](https://github.com/merlinfuchs/blimp/assets/33966852/cd7c43e3-e77e-4c8a-bfd6-3feba044c577)

closes #5 